### PR TITLE
Allow creation of more secondary index types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Application-friendly RethinkDB client
 
 [![Build Status](https://secure.travis-ci.org/hueniverse/penseur.png)](http://travis-ci.org/hueniverse/penseur)
+

--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 Application-friendly RethinkDB client
 
 [![Build Status](https://secure.travis-ci.org/hueniverse/penseur.png)](http://travis-ci.org/hueniverse/penseur)
-

--- a/lib/db.js
+++ b/lib/db.js
@@ -40,6 +40,19 @@ internals.unique = Joi.object({
 });
 
 
+internals.secondaryIndex = Joi.object({
+    name: Joi.string().required(),
+    func: Joi.alternatives().try(
+        Joi.array().items(Joi.string()),   // shortcut: list of rows for compound index
+        Joi.func()                         // a rethinkdb function
+    ),
+    options: Joi.object().keys({
+        multi: Joi.boolean().default(false),
+        geo: Joi.boolean().default(false)
+    }).default({})
+});
+
+
 internals.schema = {
     db: Joi.object({
 
@@ -68,7 +81,7 @@ internals.schema = {
     table: Joi.object({
         extended: Joi.any(),
         purge: Joi.boolean().default(true),
-        secondary: Joi.array().items(Joi.string()).single().default([]).allow(false),
+        secondary: Joi.array().items(Joi.string(), internals.secondaryIndex).single().default([]).allow(false),
         id: [
             {
                 type: 'uuid'
@@ -309,6 +322,22 @@ exports = module.exports = internals.Db = class {
         return tables;
     }
 
+    _normalizeIndexes(indexes) {
+
+        if (!indexes) {
+            return [];
+        }
+
+        indexes = [].concat(indexes);
+
+        const normalized = indexes.map((index) => {
+
+            return typeof index === 'string' ? { name: index } : index;
+        });
+
+        return normalized;
+    };
+
     _generateTable(name, options) {
 
         options = options || {};
@@ -441,10 +470,12 @@ exports = module.exports = internals.Db = class {
                         return finalize();
                     }
 
-                    const requestedIndexes = [].concat(tableOptions.secondary || []);
-                    const intersection = Hoek.intersect(existingConfig.indexes, requestedIndexes);
-                    const createIndexes = internals.difference(requestedIndexes, intersection);
+                    const requestedIndexes = this._normalizeIndexes(tableOptions.secondary);
+                    const requestedIndexNames = requestedIndexes.map((i) => i.name);
+                    const intersection = Hoek.intersect(existingConfig.indexes, requestedIndexNames);
+                    const createIndexNames = internals.difference(requestedIndexNames, intersection);
                     const removeIndexes = internals.difference(existingConfig.indexes, intersection);
+                    const createIndexes = requestedIndexes.filter((i) => createIndexNames.includes(i.name));
 
                     const eachIndex = (index, nextIndex) => {
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -265,18 +265,34 @@ exports = module.exports = class {
         });
     }
 
-    index(names, callback) {
+    index(indexes, callback) {
 
-        names = [].concat(names);
-        const each = (name, next) => {
+        indexes = this._db._normalizeIndexes(indexes);
 
-            this._run(this._table.indexCreate(name), 'index', null, (err, result) => {
+        const each = (index, next) => {
 
-                return next(err);
-            });
+            let args;
+            const { name, func, options } = index;
+
+            if (func) {
+                args = [name, Array.isArray(func) ? func.map((row) => RethinkDB.row(row)) : func, options];
+            }
+            else {
+                args = [name, options];
+            }
+
+            this._run(this._table.indexCreate.apply(this._table, args), 'index', null, next);
         };
 
-        Items.parallel(names, each, callback);
+        Items.parallel(indexes, each, (err) => {
+
+            if (err) {
+                return callback(err);
+            }
+
+            const names = indexes.map((i) => i.name);
+            this._run(this._table.indexWait(RethinkDB.args(names)), 'indexWait', null, callback);
+        });
     }
 
     changes(criteria, options, callback) {


### PR DESCRIPTION
Currently penseur only supports creating simple secondary indexes via a string, e.g.:

```js
db.test.index('name', ...);
```
This is equivalent to a secondary index on one field. The equivalent RethinkDB function is:

```js
function(row) { return row.getField("name"); }
```

However, RethinkDB allows more advanced secondary index types such as compound indexes on more than row, indexes on arbitrary expressions and multi and geo options. 

This PR adds support to Penseur for creating any type of secondary index. The new API is backwards compatible with the simple string arguments. Here's an example of the new API:

```js
db.test.index([
    'name',                                                   // a simple index on one field
    { name: 'other-name' },                                   // another simple index
    { name: 'postAuthor', func: ['post', 'author']  },        // compound index on 2 fields
    { name: 'custom', func: (doc) => { ... }  },              // index on custom function
    { name: 'author', options: { multi: true }  },            // simple index with multi option
    { name: 'location', options: { geo: true }  },            // simple index with geo option
], ...)
```

Additionally I added a step to wait for indexes to be ready before calling the `index()` callback as any queries using these indexes will throw if the indexes aren't ready yet.

Closes #96 

