### PR TITLE
Optimize for a compound index query

### DIFF
--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -45,6 +45,31 @@ exports.select = function (criteria, table) {
                 }
             }
         }
+
+        // Attempt to match query to a compound index
+
+        else {
+
+            let scalarOnly = true;
+            for (let i = 0; i < keys.length; ++i) {
+                if (typeof criteria[keys[i]] === 'object') {
+                    scalarOnly = false;
+                    break;
+                }
+            }
+
+            if (scalarOnly) {
+                for (let i = 0; i < table.secondary.length; ++i) {
+                    const index = table.secondary[i];
+                    if (typeof index === 'object' &&
+                        Array.isArray(index.source) &&
+                        Hoek.contain(keys, index.source, { once: true, only: true })) {
+
+                        return table._table.getAll(index.source.map((key) => criteria[key]), { index: index.name });
+                    }
+                }
+            }
+        }
     }
 
     // Construct query


### PR DESCRIPTION
Just a PR to generate ideas.

The `query()` optimisation in 1e4cfd9e33dbba2ee9cea7f32b6b1dd63c998a51 works great for simple secondary indexes but it doesn't give us a way to make use of compound indexes.

There's a few ways I can see to do this:

- Extend the `select()` logic to find a matching compound index (as this PR does by example)
- Offer a thin wrapper around Rethink's `getAll()` so we can make custom `getAll()` queries
- Offer a custom ReQL command API

Closes #99 