### PR TITLE
allow for "user" and "password" settings.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -163,9 +163,14 @@ exports = module.exports = internals.Db = class {
 
     _connect(callback) {
 
+        // this._settings has options passed with connection.
+        // below array restricts which options will be configured in settings.
+        // default does not have "user" or "password" which does not allow for
+        // user & password authentication.
+
         const settings = this._connectionOptions || {};
         if (!this._connectionOptions) {
-            ['host', 'port', 'db', 'authKey', 'timeout', 'ssl'].forEach((item) => {
+            ['host', 'port', 'db', 'authKey', 'timeout', 'ssl', 'user', 'password'].forEach((item) => {
 
                 if (this._settings[item] !== undefined) {
                     settings[item] = this._settings[item];


### PR DESCRIPTION
Tweaked connectionOptions array to allow "user" and "password" options.  
Otherwise, the options are ignored by penseur. This caused authentication to fail even when using valid credentials.

Perhaps, you do not want this added. But, my use case required it so
thought a PR could not hurt. 

Btw, I really enjoyed reading the code you wrote for this. 
It is really nice work!  Even the tests are a form of nice clean documentation. 
Thank you for open sourcing the project.