### PR TITLE
Backport `empty` to v7 (node 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Subscribe to changes matching the given criteria for the table.
 #### `Db.contains(values[, options])`
 #### `Db.not(values)`
 #### `Db.unset()`
+#### `Db.isEmpty()`
 #### `Db.increment(value)`
 #### `Db.append(value[, options])`
 #### `Db.override(value)`

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Subscribe to changes matching the given criteria for the table.
 #### `Db.contains(values[, options])`
 #### `Db.not(values)`
 #### `Db.unset()`
-#### `Db.isEmpty()`
+#### `Db.empty()`
 #### `Db.increment(value)`
 #### `Db.append(value[, options])`
 #### `Db.override(value)`

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -31,6 +31,15 @@ exports.select = function (criteria, table) {
 };
 
 
+internals.empty = function (path) {
+
+    const selector = path.reduce((memo, next) => memo(next), exports.row);
+    return RethinkDB.branch(
+        selector.typeOf().eq('ARRAY'), selector.isEmpty(),
+        selector.typeOf().eq('OBJECT'), selector.keys().isEmpty(),
+        false);
+};
+
 internals.compile = function (criteria, relative) {
 
     /*
@@ -96,8 +105,7 @@ internals.compile = function (criteria, relative) {
                             ors.push(exports.row(path.slice(0, -1)).hasFields(path[path.length - 1]).not());
                         }
                         else if (orValue.type === 'empty') {
-                            const selector = path.reduce((memo, next) => memo(next), exports.row);
-                            ors.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));
+                            ors.push(internals.empty(path));
                         }
                         else {
                             ors.push(internals.toComparator(row, orValue));
@@ -128,8 +136,7 @@ internals.compile = function (criteria, relative) {
 
                 // empty
 
-                const selector = path.reduce((memo, next) => memo(next), exports.row);
-                tests.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));
+                tests.push(internals.empty(path));
             }
             else {
 

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -59,8 +59,7 @@ internals.compile = function (criteria, relative) {
         if (typeof value === 'function') {
 
             // Special rule
-
-            Hoek.assert(['contains', 'is', 'not', 'or', 'unset'].indexOf(value.type) !== -1, `Unknown criteria value type ${value.type}`);
+            Hoek.assert(['contains', 'is', 'not', 'or', 'unset', 'isEmpty'].indexOf(value.type) !== -1, `Unknown criteria value type ${value.type}`);
 
             if (value.type === 'contains') {
 
@@ -92,9 +91,13 @@ internals.compile = function (criteria, relative) {
                 for (let j = 0; j < value.value.length; ++j) {
                     const orValue = value.value[j];
                     if (typeof orValue === 'function') {
-                        Hoek.assert(['unset', 'is'].indexOf(orValue.type) !== -1, `Unknown or criteria value type ${orValue.type}`);
+                        Hoek.assert(['unset', 'is', 'isEmpty'].indexOf(orValue.type) !== -1, `Unknown or criteria value type ${orValue.type}`);
                         if (orValue.type === 'unset') {
                             ors.push(exports.row(path.slice(0, -1)).hasFields(path[path.length - 1]).not());
+                        }
+                        else if (orValue.type === 'isEmpty') {
+                            const selector = path.reduce((memo, next) => memo(next), exports.row);
+                            ors.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));
                         }
                         else {
                             ors.push(internals.toComparator(row, orValue));
@@ -120,6 +123,13 @@ internals.compile = function (criteria, relative) {
                 // Is
 
                 tests.push(internals.toComparator(row, value));
+            }
+            else if (value.type === 'isEmpty') {
+
+                // isEmpty
+
+                const selector = path.reduce((memo, next) => memo(next), exports.row);
+                tests.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));
             }
             else {
 

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -59,7 +59,7 @@ internals.compile = function (criteria, relative) {
         if (typeof value === 'function') {
 
             // Special rule
-            Hoek.assert(['contains', 'is', 'not', 'or', 'unset', 'isEmpty'].indexOf(value.type) !== -1, `Unknown criteria value type ${value.type}`);
+            Hoek.assert(['contains', 'is', 'not', 'or', 'unset', 'empty'].indexOf(value.type) !== -1, `Unknown criteria value type ${value.type}`);
 
             if (value.type === 'contains') {
 
@@ -91,11 +91,11 @@ internals.compile = function (criteria, relative) {
                 for (let j = 0; j < value.value.length; ++j) {
                     const orValue = value.value[j];
                     if (typeof orValue === 'function') {
-                        Hoek.assert(['unset', 'is', 'isEmpty'].indexOf(orValue.type) !== -1, `Unknown or criteria value type ${orValue.type}`);
+                        Hoek.assert(['unset', 'is', 'empty'].indexOf(orValue.type) !== -1, `Unknown or criteria value type ${orValue.type}`);
                         if (orValue.type === 'unset') {
                             ors.push(exports.row(path.slice(0, -1)).hasFields(path[path.length - 1]).not());
                         }
-                        else if (orValue.type === 'isEmpty') {
+                        else if (orValue.type === 'empty') {
                             const selector = path.reduce((memo, next) => memo(next), exports.row);
                             ors.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));
                         }
@@ -124,9 +124,9 @@ internals.compile = function (criteria, relative) {
 
                 tests.push(internals.toComparator(row, value));
             }
-            else if (value.type === 'isEmpty') {
+            else if (value.type === 'empty') {
 
-                // isEmpty
+                // empty
 
                 const selector = path.reduce((memo, next) => memo(next), exports.row);
                 tests.push(selector.typeOf().eq('ARRAY').and(selector.isEmpty()));

--- a/lib/db.js
+++ b/lib/db.js
@@ -645,9 +645,9 @@ exports = module.exports = internals.Db = class {
         return internals.special('by', [].concat(values), { index });
     }
 
-    static isEmpty() {
+    static empty() {
 
-        return internals.special('isEmpty');
+        return internals.special('empty');
     }
 
     // Criteria or Modifier
@@ -680,7 +680,7 @@ internals.Db.prototype.or = internals.Db.or;
 internals.Db.prototype.contains = internals.Db.contains;
 internals.Db.prototype.not = internals.Db.not;
 internals.Db.prototype.unset = internals.Db.unset;
-internals.Db.prototype.isEmpty = internals.Db.isEmpty;
+internals.Db.prototype.empty = internals.Db.empty;
 internals.Db.prototype.increment = internals.Db.increment;
 internals.Db.prototype.append = internals.Db.append;
 internals.Db.prototype.override = internals.Db.override;

--- a/lib/db.js
+++ b/lib/db.js
@@ -645,6 +645,11 @@ exports = module.exports = internals.Db = class {
         return internals.special('by', [].concat(values), { index });
     }
 
+    static isEmpty() {
+
+        return internals.special('isEmpty');
+    }
+
     // Criteria or Modifier
 
     static unset() {
@@ -675,6 +680,7 @@ internals.Db.prototype.or = internals.Db.or;
 internals.Db.prototype.contains = internals.Db.contains;
 internals.Db.prototype.not = internals.Db.not;
 internals.Db.prototype.unset = internals.Db.unset;
+internals.Db.prototype.isEmpty = internals.Db.isEmpty;
 internals.Db.prototype.increment = internals.Db.increment;
 internals.Db.prototype.append = internals.Db.append;
 internals.Db.prototype.override = internals.Db.override;

--- a/test/criteria.js
+++ b/test/criteria.js
@@ -492,14 +492,53 @@ describe('Criteria', { parallel: false }, () => {
 
             expect(err).to.not.exist();
 
+            db.test.insert([{ id: 1, a: 1, b: null }, { id: 2, a: 1, b: [2] }, { id: 3, a: 2, b: [] }, { id: 4, a: 1, b: 3 }, { id: 5, a: 1, b: { } }], (err, keys) => {
+
+                expect(err).to.not.exist();
+                db.test.query({ a: 1, b: db.empty() }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 5, a: 1, b: { } }]);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('parses nested empty key for arrays', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
             db.test.insert([{ id: 1, a: 1, b: { c: null } }, { id: 2, a: 1, b: { c: [2] } }, { id: 3, a: 1, b: { c: [] } }, { id: 4, a: 1, b: { c: 3 } }], (err, keys) => {
 
                 expect(err).to.not.exist();
-
                 db.test.query({ a: 1, b: { c: db.empty() } }, (err, result) => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 3, a: 1, b: { c: [] } }]);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('parses nested empty key for objects', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
+            db.test.insert([{ id: 1, a: 1, b: { c: null } }, { id: 2, a: 1, b: { c: { d: 4 } } }, { id: 3, a: 1, b: { c: {} } }, { id: 4, a: 1, b: { c: 3 } }], (err, keys) => {
+
+                expect(err).to.not.exist();
+                db.test.query({ a: 1, b: { c: db.empty() } }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 3, a: 1, b: { c: {} } }]);
                     done();
                 });
             });

--- a/test/criteria.js
+++ b/test/criteria.js
@@ -179,7 +179,7 @@ describe('Criteria', { parallel: false }, () => {
         });
     });
 
-    it('parses or isEmpty', (done) => {
+    it('parses or empty', (done) => {
 
         const db = new Penseur.Db('penseurtest');
         db.establish(['test'], (err) => {
@@ -189,7 +189,7 @@ describe('Criteria', { parallel: false }, () => {
             db.test.insert([{ id: 1, a: [] }, { id: 2, a: 1 }, { id: 3, a: [2] }], (err, keys) => {
 
                 expect(err).to.not.exist();
-                db.test.query({ a: db.or([1, db.isEmpty()]) }, (err, result) => {
+                db.test.query({ a: db.or([1, db.empty()]) }, (err, result) => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 2, a: 1 }, { id: 1, a: [] }]);
@@ -199,7 +199,7 @@ describe('Criteria', { parallel: false }, () => {
         });
     });
 
-    it('parses or isEmpty nested', (done) => {
+    it('parses or empty nested', (done) => {
 
         const db = new Penseur.Db('penseurtest');
         db.establish(['test'], (err) => {
@@ -209,7 +209,7 @@ describe('Criteria', { parallel: false }, () => {
             db.test.insert([{ id: 1, a: 1, b: { c: [1] } }, { id: 2, a: 1, b: { c: [] } }, { id: 3, a: 1, b: { c: 66 } }], (err, keys) => {
 
                 expect(err).to.not.exist();
-                db.test.query({ a: 1, b: { c: db.or([66, db.isEmpty()]) } }, (err, result) => {
+                db.test.query({ a: 1, b: { c: db.or([66, db.empty()]) } }, (err, result) => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 3, a: 1, b: { c: 66 } }, { id: 2, a: 1, b: { c: [] } }]);
@@ -219,7 +219,7 @@ describe('Criteria', { parallel: false }, () => {
         });
     });
 
-    it('parses not isEmpty nested', (done) => {
+    it('parses not empty nested', (done) => {
 
         const db = new Penseur.Db('penseurtest');
         db.establish(['test'], (err) => {
@@ -229,7 +229,7 @@ describe('Criteria', { parallel: false }, () => {
             db.test.insert([{ id: 1, a: 1, b: { c: [1] } }, { id: 2, a: 1, b: { c: [] } }, { id: 3, a: 1, b: { c: 66 } }], (err, keys) => {
 
                 expect(err).to.not.exist();
-                db.test.query({ a: 1, b: { c: db.not([66, db.isEmpty()]) } }, (err, result) => {
+                db.test.query({ a: 1, b: { c: db.not([66, db.empty()]) } }, (err, result) => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 1, a: 1, b: { c: [1] } }]);
@@ -485,7 +485,7 @@ describe('Criteria', { parallel: false }, () => {
         });
     });
 
-    it('parses isEmpty key', (done) => {
+    it('parses empty key', (done) => {
 
         const db = new Penseur.Db('penseurtest');
         db.establish(['test'], (err) => {
@@ -496,7 +496,7 @@ describe('Criteria', { parallel: false }, () => {
 
                 expect(err).to.not.exist();
 
-                db.test.query({ a: 1, b: { c: db.isEmpty() } }, (err, result) => {
+                db.test.query({ a: 1, b: { c: db.empty() } }, (err, result) => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 3, a: 1, b: { c: [] } }]);

--- a/test/criteria.js
+++ b/test/criteria.js
@@ -179,6 +179,66 @@ describe('Criteria', { parallel: false }, () => {
         });
     });
 
+    it('parses or isEmpty', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
+            db.test.insert([{ id: 1, a: [] }, { id: 2, a: 1 }, { id: 3, a: [2] }], (err, keys) => {
+
+                expect(err).to.not.exist();
+                db.test.query({ a: db.or([1, db.isEmpty()]) }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 2, a: 1 }, { id: 1, a: [] }]);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('parses or isEmpty nested', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
+            db.test.insert([{ id: 1, a: 1, b: { c: [1] } }, { id: 2, a: 1, b: { c: [] } }, { id: 3, a: 1, b: { c: 66 } }], (err, keys) => {
+
+                expect(err).to.not.exist();
+                db.test.query({ a: 1, b: { c: db.or([66, db.isEmpty()]) } }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 3, a: 1, b: { c: 66 } }, { id: 2, a: 1, b: { c: [] } }]);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('parses not isEmpty nested', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
+            db.test.insert([{ id: 1, a: 1, b: { c: [1] } }, { id: 2, a: 1, b: { c: [] } }, { id: 3, a: 1, b: { c: 66 } }], (err, keys) => {
+
+                expect(err).to.not.exist();
+                db.test.query({ a: 1, b: { c: db.not([66, db.isEmpty()]) } }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 1, a: 1, b: { c: [1] } }]);
+                    done();
+                });
+            });
+        });
+    });
+
     it('parses or root', (done) => {
 
         const db = new Penseur.Db('penseurtest');
@@ -419,6 +479,27 @@ describe('Criteria', { parallel: false }, () => {
 
                     expect(err).to.not.exist();
                     expect(result).to.equal([{ id: 3, a: 1, b: { c: null } }, { id: 2, a: 1, b: { d: 3 } }]);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('parses isEmpty key', (done) => {
+
+        const db = new Penseur.Db('penseurtest');
+        db.establish(['test'], (err) => {
+
+            expect(err).to.not.exist();
+
+            db.test.insert([{ id: 1, a: 1, b: { c: null } }, { id: 2, a: 1, b: { c: [2] } }, { id: 3, a: 1, b: { c: [] } }, { id: 4, a: 1, b: { c: 3 } }], (err, keys) => {
+
+                expect(err).to.not.exist();
+
+                db.test.query({ a: 1, b: { c: db.isEmpty() } }, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.equal([{ id: 3, a: 1, b: { c: [] } }]);
                     done();
                 });
             });


### PR DESCRIPTION
This is a backport of https://github.com/hueniverse/penseur/pull/141 which added `empty` support into penseur.

This has been primarily done to support node 6