### PR TITLE
Allows calls to table.count() with no criteria

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -177,7 +177,7 @@ exports = module.exports = internals.Table = class {
         }
     }
 
-    async count(criteria) {
+    async count(criteria = null) {
 
         const track = { table: this.name, action: 'count', inputs: { criteria } };
 

--- a/test/table.js
+++ b/test/table.js
@@ -523,6 +523,24 @@ describe('Table', () => {
             expect(result).to.equal(3);
         });
 
+        it('returns the total count if criteria is null', async () => {
+
+            const db = new Penseur.Db('penseurtest');
+            await db.establish(['test']);
+            await db.test.insert([{ id: 1, a: 1 }, { id: 2, a: 2 }, { id: 3, a: 1 }]);
+            const result = await db.test.count(null);
+            expect(result).to.equal(3);
+        });
+
+        it('returns the total count if no criteria is passed in', async () => {
+
+            const db = new Penseur.Db('penseurtest');
+            await db.establish(['test']);
+            await db.test.insert([{ id: 1, a: 1 }, { id: 2, a: 2 }, { id: 3, a: 1 }]);
+            const result = await db.test.count();
+            expect(result).to.equal(3);
+        });
+
         it('fails on database error', async () => {
 
             const db = new Penseur.Db('penseurtest');


### PR DESCRIPTION
We had a bug where the dev expected to be able to call `table.count()` and get back the count of the entire table. Instead it throws because it tries to call `Object.keys()` on the undefined criteria.

I think this is a nice extension to `count`. What do you think?